### PR TITLE
fix: add backquote "table name" and "column names"

### DIFF
--- a/src/main/java/org/embulk/output/cdata/CDataPageOutputForInsert.java
+++ b/src/main/java/org/embulk/output/cdata/CDataPageOutputForInsert.java
@@ -46,8 +46,8 @@ public class CDataPageOutputForInsert implements TransactionalPageOutput {
     ArrayList<String> preparedValues = pageReader.getSchema().getColumns().stream()
             .map(it -> "?").collect(Collectors.toCollection(ArrayList::new));
 
-    String insertTempStatement = "INSERT INTO " + insertTempTable + "(" +
-            String.join(", ", columnNames) +
+    String insertTempStatement = "INSERT INTO `" + insertTempTable + "` (" +
+            columnNames.stream().collect(Collectors.joining("`, `", "`", "`")) +
             ") VALUES (" +
             String.join(", ", preparedValues) + ")";
     logger.info(insertTempStatement);
@@ -64,14 +64,14 @@ public class CDataPageOutputForInsert implements TransactionalPageOutput {
         throw new RuntimeException(e);
       }
     }
-    
-    String insertStatement = "INSERT INTO " + task.getTable() + " (" +
-            String.join(", ", columnNames) +
+
+    String insertStatement = "INSERT INTO `" + task.getTable() + "` (" +
+            columnNames.stream().collect(Collectors.joining("`, `", "`", "`")) +
             ") SELECT " +
-            String.join(", ", columnNames) +
-            " FROM " + insertTempTable;
+            columnNames.stream().collect(Collectors.joining("`, `", "`", "`")) +
+            " FROM `" + insertTempTable + "`";
     logger.info(insertStatement);
-    
+
     try {
       this.preparedStatement = conn.prepareStatement(insertStatement, Statement.RETURN_GENERATED_KEYS);
       pageReader.getSchema().visitColumns(createColumnVisitor(preparedStatement));

--- a/src/main/java/org/embulk/output/cdata/CDataPageOutputForManualUpsert.java
+++ b/src/main/java/org/embulk/output/cdata/CDataPageOutputForManualUpsert.java
@@ -140,7 +140,7 @@ public class CDataPageOutputForManualUpsert extends CDataPageOutputForUpsertBase
     protected ResultSet selectRecordAll(String tableName, List<String> selectColumns) {
         try {
             Statement selectStatement = getConnection().createStatement();
-            return selectStatement.executeQuery("SELECT " + String.join(", ", selectColumns) + " FROM " + tableName);
+            return selectStatement.executeQuery("SELECT " + selectColumns.stream().collect(Collectors.joining("`, `", "`", "`")) + " FROM `" + tableName + "`");
 
         } catch (SQLException e) {
             throw new RuntimeException(e);

--- a/src/main/java/org/embulk/output/cdata/CDataPageOutputForUpdate.java
+++ b/src/main/java/org/embulk/output/cdata/CDataPageOutputForUpdate.java
@@ -45,7 +45,7 @@ public class CDataPageOutputForUpdate implements TransactionalPageOutput {
     preparedValues.add("?"); // for Id
 
     HashMap<String, String> idMap = new HashMap<>();
-    String selectStatement = "SELECT " + String.join(", ", columnNamesWithId) + " FROM " + task.getTable();
+    String selectStatement = "SELECT " + columnNamesWithId.stream().collect(Collectors.joining("`, `", "`", "`")) + " FROM `" + task.getTable() + "`";
     logger.info(selectStatement);
     try {
       Statement statement = conn.createStatement();
@@ -69,8 +69,8 @@ public class CDataPageOutputForUpdate implements TransactionalPageOutput {
       throw new RuntimeException(e);
     }
 
-    String insertStatement = "INSERT INTO " + insertTempTable + "(" +
-      String.join(", ", columnNamesWithId) +
+    String insertStatement = "INSERT INTO `" + insertTempTable + "` (" +
+      columnNamesWithId.stream().collect(Collectors.joining("`, `", "`", "`")) +
       ") VALUES (" +
       String.join(", ", preparedValues) + ")";
     logger.info(insertStatement);
@@ -174,11 +174,11 @@ public class CDataPageOutputForUpdate implements TransactionalPageOutput {
       }
     }
     try {
-      String updateStatement = "UPDATE " + task.getTable() + " (" +
-        String.join(", ", columnNamesWithId) +
+      String updateStatement = "UPDATE `" + task.getTable() + "` (" +
+        columnNamesWithId.stream().collect(Collectors.joining("`, `", "`", "`")) +
         ") SELECT " +
-        String.join(", ", columnNamesWithId) +
-        " FROM " + insertTempTable;
+        columnNamesWithId.stream().collect(Collectors.joining("`, `", "`", "`")) +
+        " FROM `" + insertTempTable + "`";
       logger.info(updateStatement);
       conn.createStatement().executeUpdate(updateStatement, Statement.RETURN_GENERATED_KEYS);
     } catch (SQLException e) {

--- a/src/main/java/org/embulk/output/cdata/CDataPageOutputForUpsert.java
+++ b/src/main/java/org/embulk/output/cdata/CDataPageOutputForUpsert.java
@@ -34,11 +34,11 @@ public class CDataPageOutputForUpsert extends CDataPageOutputForUpsertBase {
     }
 
     protected String createUpsertQuery(String tableName, List<String> columnNames) {
-        return "UPSERT INTO " + tableName + " (" +
-                String.join(", ", columnNames) +
+        return "UPSERT INTO `" + tableName + "` (" +
+                columnNames.stream().collect(Collectors.joining("`, `", "`", "`")) +
                 ") SELECT " +
-                String.join(", ", columnNames) +
-                " FROM " + INSERT_TEMP_TABLE;
+                columnNames.stream().collect(Collectors.joining("`, `", "`", "`")) +
+                " FROM `" + INSERT_TEMP_TABLE + "`";
     }
 
     protected ExecutedInsertResult executeInsert(List<String> columnNames, List<String> preparedValues) throws SQLException {

--- a/src/main/java/org/embulk/output/cdata/CDataPageOutputForUpsertBase.java
+++ b/src/main/java/org/embulk/output/cdata/CDataPageOutputForUpsertBase.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 
 import java.sql.*;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class CDataPageOutputForUpsertBase implements TransactionalPageOutput {
 
@@ -103,8 +104,8 @@ public class CDataPageOutputForUpsertBase implements TransactionalPageOutput {
    * @return
    */
   protected String createInsertQuery(String tableName, List<String> columnNames, List<String> preparedValues) {
-    return "INSERT INTO " + tableName + "(" +
-            String.join(", ", columnNames) +
+    return "INSERT INTO `" + tableName + "` (" +
+            columnNames.stream().collect(Collectors.joining("`, `", "`", "`")) +
             ") VALUES (" +
             String.join(", ", preparedValues) + ")";
   }


### PR DESCRIPTION
対応内容

テーブル名およびカラム名にバッククォートの追加